### PR TITLE
fix: VisualGDB engine switching breaks Doxygen highlighting

### DIFF
--- a/VSDoxyHighlighter/CommentClassifier.cs
+++ b/VSDoxyHighlighter/CommentClassifier.cs
@@ -107,6 +107,7 @@ namespace VSDoxyHighlighter
   /// GetClassifier() is called by Visual Studio to create a new classifier to a given text buffer.
   /// </summary>
   [Export(typeof(IClassifierProvider))]
+  [ContentType("text")]
   [ContentType("C/C++")]
   internal class CommentClassifierProvider : IClassifierProvider
   {

--- a/VSDoxyHighlighter/VisualStudioCppColorer.cs
+++ b/VSDoxyHighlighter/VisualStudioCppColorer.cs
@@ -50,6 +50,7 @@ namespace VSDoxyHighlighter
     public DefaultVSCppColorerImpl(ITextBuffer textBuffer) 
     {
       mTextBuffer = textBuffer;
+      mLastKnownContentType = textBuffer.ContentType?.TypeName ?? "null";
       InitializeLazily();
     }
 
@@ -79,6 +80,14 @@ namespace VSDoxyHighlighter
     {
       // vsCppTagger.GetTags() seems to return no tags at all if we are not on the main thread.
       ThreadHelper.ThrowIfNotOnUIThread();
+
+      // Track ContentType changes (e.g. VisualGDB engine switching) 
+      // but keep the existing tagger reference - do NOT reset it.
+      var currentContentType = mTextBuffer.ContentType?.TypeName ?? "null";
+      if (mLastKnownContentType != currentContentType)
+      {
+        mLastKnownContentType = currentContentType;
+      }
 
       var vsCppTagger = FindDefaultVSCppTagger();
       if (vsCppTagger == null) {
@@ -144,6 +153,7 @@ namespace VSDoxyHighlighter
 
 
     private readonly ITextBuffer mTextBuffer;
+    private string mLastKnownContentType;
 
     // Cached tagger that is used by Visual Studio to classify C/C++ code.
     private ITagger<IClassificationTag> mDefaultVSCppTagger = null;

--- a/VSDoxyHighlighter/VisualStudioCppFileSemantics.cs
+++ b/VSDoxyHighlighter/VisualStudioCppFileSemantics.cs
@@ -1,4 +1,4 @@
-﻿using EnvDTE;
+using EnvDTE;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
@@ -581,12 +581,19 @@ namespace VSDoxyHighlighter
     public CppFileSemanticsFromSemanticTokensCache(ITextBuffer textBuffer) 
     { 
       mTextBuffer = textBuffer;
+      mLastKnownContentType = textBuffer.ContentType?.TypeName ?? "null";
       InitializeLazily();
     }
 
 
     public void InitializeLazily()
     {
+      var currentContentType = mTextBuffer.ContentType?.TypeName ?? "null";
+      if (currentContentType != mLastKnownContentType)
+      {
+        mLastKnownContentType = currentContentType;
+      }
+      
       FindVSSemanticsTokenCache();
     }
 
@@ -876,6 +883,7 @@ namespace VSDoxyHighlighter
 
     private readonly ITextBuffer mTextBuffer;
     private VSSemanticTokensCache mVSSemanticTokensCache;
+    private string mLastKnownContentType;
   }
 
 


### PR DESCRIPTION
fix: VisualGDB engine switching breaks Doxygen highlighting

When VisualGDB switches between its Native VC++ and Clang engines, the
text buffer's ContentType changes (e.g. "C/C++" → "C/C++ (VisualGDB)"),
causing the plugin to stop working.

Changes:
- CommentClassifierProvider: Added [ContentType("text")] so the classifier
  is still invoked after ContentType changes.
- VisualStudioCppColorer: Track ContentType changes in TryGetTags() to
  keep the tagger reference alive across engine switches.
- VisualStudioCppFileSemantics: Same tracking in
  CppFileSemanticsFromSemanticTokensCache to preserve the semantic cache.
  
  > Based on commit fab3a42 ("Explaining how .dox files can be treated as C++ files").